### PR TITLE
Fixed query error

### DIFF
--- a/ActiveQuery.php
+++ b/ActiveQuery.php
@@ -32,7 +32,7 @@ class ActiveQuery extends YiiActiveQuery {
 			throw new Exception('Only MqSQL and PostgreSQL are supported by ' . self::className());
 		}
 
-        $this->from(['distance' => $subQuery])
+        $this->from([$modelCls::tableName() => $subQuery])
             ->andWhere([ '<', '_d', $radius ])
             ->orderBy([
                 '_d' => SORT_ASC


### PR DESCRIPTION
Query fails if founds entries:

```SQL
SELECT `stock`.*, ST_AsText(location) AS location
FROM (
  SELECT s.*, (111.045 * ST_Distance(location, ST_PointFromText('POINT(41.5266252 12.9459433)'))) AS `_d` FROM `stock` as s
) `distance`
WHERE `_d` < '800'
ORDER BY `_d`
LIMIT 20
```

Error: 
[2018-12-11 09:27:37] [42S02][1051] Unknown table 'stock'

The `distance` keyword must be replaced with table name.